### PR TITLE
Read optimization globally

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,8 +13,8 @@ Improvements
 * Global read optimization
   (`#11 <https://github.com/tensorwerk/stockroom/pull/11>`__) `@hhsecond <https://github.com/hhecond>`__
 
-* Integrated hangar's new column API
-  (`#)
+* Hangar's new column API
+  (`#12 <https://github.com/tensorwerk/stockroom/pull/12>`__) `@hhsecond <https://github.com/hhecond>`__
 
 
 v0.1.0_ (2019-12-12)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,25 @@
 History
 =======
 
-0.1.0 (2019-12-12)
+In-Progress_
+==============
+
+Improvements
+------------
+* Singleton for holding the checkout object has been removed
+  (`#3 <https://github.com/tensorwerk/stockroom/pull/3>`__) `@hhsecond <https://github.com/hhecond>`__
+
+* Global read optimization
+  (`#11 <https://github.com/tensorwerk/stockroom/pull/11>`__) `@hhsecond <https://github.com/hhecond>`__
+
+* Integrated hangar's new column API
+  (`#)
+
+
+v0.1.0_ (2019-12-12)
 ------------------
 
 * First release on PyPI.
+
+.. _v0.1.0: https://github.com/tensorwerk/stockroom/releases/tag/v0.1.0
+.. _In-Progress: https://github.com/tensorwerk/stockroom

--- a/stockroom/main.py
+++ b/stockroom/main.py
@@ -94,7 +94,6 @@ class StockRoom:
             self._stock_repo.open_global_writer()
             yield
         finally:
-            # this guard is necessary if exception while opening checkout
             if self._stock_repo.is_write_optimized:
                 self._stock_repo.close_global_writer()
 
@@ -105,7 +104,6 @@ class StockRoom:
         close after the commit. Which means, no other write operations should be running
         while stock commit is in progress
         """
-        # TODO: should we update the head here? If update, change the test cases too
         with self._stock_repo.get_writer_cm() as writer:
             digest = writer.commit(message)
         set_current_head(self._stock_repo.stockroot, digest)

--- a/stockroom/main.py
+++ b/stockroom/main.py
@@ -93,7 +93,8 @@ class StockRoom:
             self._repo.open_global_checkout(write)
             yield None
         finally:
-            self._repo.close_global_checkout()
+            if self._repo.is_optimized:
+                self._repo.close_global_checkout()
 
     def commit(self, message: str) -> str:
         """

--- a/stockroom/parser.py
+++ b/stockroom/parser.py
@@ -5,8 +5,8 @@ PREFIX = '_STK'
 # ===================================================================
 #         Metadata & Column key parsers for model store
 # ===================================================================
-def model_metakey(model, name):
-    return f"{PREFIX}{SEP}{model}{SEP}{name}"
+def model_metakey(name):
+    return f"{PREFIX}{SEP}{name}{SEP}meta"
 
 
 def modelkey(name, longest, dtype):

--- a/stockroom/parser.py
+++ b/stockroom/parser.py
@@ -3,7 +3,7 @@ PREFIX = '_STK'
 
 
 # ===================================================================
-#         Metadata & Arrayset key parsers for model store
+#         Metadata & Column key parsers for model store
 # ===================================================================
 def model_metakey(model, name):
     return f"{PREFIX}{SEP}{model}{SEP}{name}"

--- a/stockroom/repository.py
+++ b/stockroom/repository.py
@@ -35,7 +35,7 @@ class StockRepository:
 
         if write:
             self._optimized_Wcheckout = self._hangar_repo.checkout(write=True)
-            if self._optimized_Wcheckout.commit_hash != head_commit:
+            if head_commit and self._optimized_Wcheckout.commit_hash != head_commit:
                 self._optimized_Wcheckout.close()
                 raise RuntimeError("Writing on top of the old commit's are not allowed. "
                                    "Checkout to the latest commit")
@@ -91,7 +91,7 @@ class StockRepository:
         else:
             head_commit = get_current_head(self._root)
             co = self._hangar_repo.checkout(write=True)
-            if co.commit_hash != head_commit:
+            if head_commit and co.commit_hash != head_commit:
                 co.close()
                 raise RuntimeError("Writing on top of the old commit's are not allowed. "
                                    "Checkout to the latest commit")

--- a/stockroom/repository.py
+++ b/stockroom/repository.py
@@ -5,7 +5,17 @@ from hangar import Repository
 from .utils import get_current_head
 
 
+class Reader:
+    # TODO: explain the need
+    def __get__(self, stock, obj_type=None) -> object:
+        if 'reader' not in stock.__dict__:
+            stock.__dict__['reader'] = stock.hangar_repo.checkout(commit=stock.head)
+            stock.__dict__['reader'].__enter__()
+        return stock.__dict__['reader']
+
+
 class StockRepository:
+    # TODO: Document specifically about reader & writer
     """
     A StockRoom wrapper class for hangar repo operations. Every hangar repo interactions
     that is being done through stockroom (other than stock init) should go through the
@@ -15,90 +25,56 @@ class StockRepository:
     instantiation.
     """
 
+    reader = Reader()
+
     def __init__(self, root):
         self._root = root
-        self._hangar_repo = Repository(root)
-        self._optimized_Rcheckout = None
-        self._optimized_Wcheckout = None
-        self._has_optimized = {'R': False, 'W': False}
+        self.head = get_current_head(self._root)
+        self.hangar_repo = Repository(root)
+        # TODO: Write test cases for read optimized always
+        if self.head:
+            self.reader = self.hangar_repo.checkout(commit=self.head).__enter__()
+        self._writer = None
 
     @property
-    def hangar_repository(self):
-        return self._hangar_repo
+    def is_write_optimized(self):
+        return False if self._writer is None else True
 
-    @property
-    def is_optimized(self):
-        return any(self._has_optimized.values())
+    def open_global_writer(self):
+        self._writer = self.hangar_repo.checkout(write=True)
+        if self.head and self._writer.commit_hash != self.head:
+            self._writer.close()
+            self._writer = None
+            raise RuntimeError("Writing on top of the old commit's are not allowed. "
+                               "Checkout to the latest commit")
+        self._writer.__enter__()
 
-    def open_global_checkout(self, write):
-        head_commit = get_current_head(self._root)
-
-        if write:
-            self._optimized_Wcheckout = self._hangar_repo.checkout(write=True)
-            if head_commit and self._optimized_Wcheckout.commit_hash != head_commit:
-                self._optimized_Wcheckout.close()
-                raise RuntimeError("Writing on top of the old commit's are not allowed. "
-                                   "Checkout to the latest commit")
-            self._optimized_Wcheckout.__enter__()
-            self._has_optimized['W'] = True
-
-        self._optimized_Rcheckout = self._hangar_repo.checkout(commit=head_commit)
-        self._optimized_Rcheckout.__enter__()
-        self._has_optimized['R'] = True
-
-    def close_global_checkout(self):
-        self._has_optimized['R'] = False
-        self._optimized_Rcheckout.__exit__()
-        self._optimized_Rcheckout.close()
-        self._optimized_Rcheckout = None
-        if self._has_optimized['W']:
-            self._has_optimized['W'] = False
-            self._optimized_Wcheckout.__exit__()
-            self._optimized_Wcheckout.close()
-            self._optimized_Wcheckout = None
+    def close_global_writer(self):
+        self._writer.__exit__()
+        self._writer.close()
+        self._writer = None
 
     @contextmanager
-    def read_checkout(self):
-        """
-        An api similar to hangar checkout in read mode but creates the checkout object
-        using the commit hash from stock file instead of user supplying one. This enables
-        users to rely on git checkout for hangar checkout as well. This checkout is being
-        designed as a context manager that makes sure the checkout is closed. On entry
-        and exit, the CM checks the existence of a global checkout. On entry, if global
-        checkout exists, it returns the that instead of creating a new checkout. On exit,
-        it doesn't close in case of global checkout instead it lets the CM do the closure
-        """
-        if self._has_optimized['R']:
-            co = self._optimized_Rcheckout
-        else:
-            head_commit = get_current_head(self._root)
-            co = self._hangar_repo.checkout(commit=head_commit)
-        try:
-            yield co
-        finally:
-            if not self._has_optimized['R']:
-                co.close()
-
-    @contextmanager
-    def write_checkout(self):
+    def get_writer_cm(self):
+        # TODO: Do the function assignment as at the time of global checkout creation and
+        # check if that improves time
         """
         An API similar to hangar checkout in write mode but does the closure of checkout
         on the exit of CM. It also monitors the existence of global checkout and open
         or close a local checkout if the global checkout doesn't exist
         """
-        if self._has_optimized['W']:
-            co = self._optimized_Wcheckout
+        if self._writer:
+            co = self._writer
         else:
-            head_commit = get_current_head(self._root)
-            co = self._hangar_repo.checkout(write=True)
-            if head_commit and co.commit_hash != head_commit:
+            co = self.hangar_repo.checkout(write=True)
+            if self.head and co.commit_hash != self.head:
                 co.close()
                 raise RuntimeError("Writing on top of the old commit's are not allowed. "
                                    "Checkout to the latest commit")
         try:
             yield co
         finally:
-            if not self._has_optimized['W']:
+            if self._writer is None:
                 co.close()
 
     @property
@@ -107,6 +83,12 @@ class StockRepository:
         Returns the root of stock repository
         """
         return self._root
+
+    def update_head(self):
+        self.head = get_current_head(self._root)
+        self.reader.__exit__()
+        self.reader.close()
+        self.reader = self.hangar_repo.checkout(commit=self.head).__enter__()
 
 
 # ================================== User facing Repository functions ================================

--- a/stockroom/storages/data.py
+++ b/stockroom/storages/data.py
@@ -1,3 +1,5 @@
+from ..repository import StockRepository
+
 
 class Data:
     """
@@ -24,13 +26,12 @@ class Data:
     >>> with stock.optimize():
     ...     sample = stock.data['coloumn1', 'sample1']
     """
-    def __init__(self, repo):
-        self._repo = repo
+    def __init__(self, repo: StockRepository):
+        self._stock_repo = repo
 
     def __setitem__(self, key, value):
-        with self._repo.write_checkout() as co:
-            co[key] = value
+        with self._stock_repo.get_writer_cm() as writer:
+            writer[key] = value
 
     def __getitem__(self, key):
-        with self._repo.read_checkout() as co:
-            return co[key]
+        return self._stock_repo.reader[key]

--- a/stockroom/storages/model.py
+++ b/stockroom/storages/model.py
@@ -75,16 +75,16 @@ class Model:
                         modelKey, longest, np.dtype(dtypes[i]), variable_shape=True)
             # ---------------------------------------------------------
 
-            shape_aset = co.columns[shapeKey]
+            shape_col = co.columns[shapeKey]
             for i, w in enumerate(weights):
-                model_aset = co.columns[parser.modelkey(name, longest, dtypes[i])]
-                model_aset[i] = w.reshape(-1)
+                model_col = co.columns[parser.modelkey(name, longest, dtypes[i])]
+                model_col[i] = w.reshape(-1)
                 if w.shape:
-                    shape_aset[i] = np.array(w.shape)
+                    shape_col[i] = np.array(w.shape)
                 else:
                     # C long = int32 in win64; int64 elsewhere
                     shape_typ = np.array(1).dtype
-                    shape_aset[i] = np.array(()).astype(shape_typ)
+                    shape_col[i] = np.array(()).astype(shape_typ)
 
     def __getitem__(self, name):
         with self._repo.read_checkout() as co:
@@ -101,12 +101,12 @@ class Model:
             layers = parser.destringify(metacol['layers'])
 
             shapeKey = parser.model_shapekey(name, longest)
-            shape_aset = co.columns[shapeKey]
+            shape_col = co.columns[shapeKey]
             weights = []
             for i in range(num_layers):
                 modelKey = parser.modelkey(name, longest, dtypes[i])
-                aset = co.columns[modelKey]
-                w = aset[i].reshape(np.array(shape_aset[i]))
+                col = co.columns[modelKey]
+                w = col[i].reshape(np.array(shape_col[i]))
                 weights.append(w)
             if library == 'torch':
                 if torch.__version__ != library_version:

--- a/stockroom/storages/model.py
+++ b/stockroom/storages/model.py
@@ -60,21 +60,21 @@ class Model:
             co.metadata[parser.model_metakey(name, 'numLayers')] = str(len(weights))
             co.metadata[parser.model_metakey(name, 'layers')] = parser.stringify(layers)
 
-            # ---------- Create arraysets if not exist -----------------
+            # ---------- Create columns if not exist -----------------
             shapeKey = parser.model_shapekey(name, str(longest))
-            if shapeKey not in co.arraysets.keys():
+            if shapeKey not in co.columns.keys():
                 shape_typ = np.array(1).dtype  # C long = int32 in win64; int64 elsewhere
-                co.arraysets.init_arrayset(shapeKey, 10, shape_typ, variable_shape=True)
+                co.add_ndarray_column(shapeKey, 10, shape_typ, variable_shape=True)
             for i, w in enumerate(weights):
                 modelKey = parser.modelkey(name, str(longest), dtypes[i])
-                if modelKey not in co.arraysets.keys():
-                    co.arraysets.init_arrayset(
+                if modelKey not in co.columns.keys():
+                    co.add_ndarray_column(
                         modelKey, longest, np.dtype(dtypes[i]), variable_shape=True)
             # ---------------------------------------------------------
 
-            shape_aset = co.arraysets[shapeKey]
+            shape_aset = co.columns[shapeKey]
             for i, w in enumerate(weights):
-                model_aset = co.arraysets[parser.modelkey(name, longest, dtypes[i])]
+                model_aset = co.columns[parser.modelkey(name, longest, dtypes[i])]
                 model_aset[i] = w.reshape(-1)
                 if w.shape:
                     shape_aset[i] = np.array(w.shape)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def repo_with_aset(repo):
     repo = hangar.Repository(Path.cwd())
     co = repo.checkout(write=True)
     arr = np.arange(20).reshape(4, 5)
-    co.arraysets.init_arrayset('aset', prototype=arr)
+    co.columns.init_arrayset('aset', prototype=arr)
     co.commit('init aset')
     co.close()
     yield None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def repo_with_aset(repo):
     repo = hangar.Repository(Path.cwd())
     co = repo.checkout(write=True)
     arr = np.arange(20).reshape(4, 5)
-    co.columns.init_arrayset('aset', prototype=arr)
+    co.add_ndarray_column('aset', prototype=arr)
     co.commit('init aset')
     co.close()
     yield None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,4 +45,4 @@ def repo_with_col(repo):
 def stock(repo_with_col):
     stock_obj = StockRoom()
     yield stock_obj
-    stock_obj._repo.hangar_repository._env._close_environments()
+    stock_obj._stock_repo.hangar_repo._env._close_environments()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,19 +30,19 @@ def repo(monkeypatch, managed_tmpdir):
 
 
 @pytest.fixture()
-def repo_with_aset(repo):
+def repo_with_col(repo):
     repo = hangar.Repository(Path.cwd())
     co = repo.checkout(write=True)
     arr = np.arange(20).reshape(4, 5)
-    co.add_ndarray_column('aset', prototype=arr)
-    co.commit('init aset')
+    co.add_ndarray_column('ndcol', prototype=arr)
+    co.commit('init column')
     co.close()
     yield None
     repo._env._close_environments()
 
 
 @pytest.fixture()
-def stock(repo_with_aset):
+def stock(repo_with_col):
     stock_obj = StockRoom()
     yield stock_obj
     stock_obj._repo.hangar_repository._env._close_environments()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,5 +36,6 @@ def test_commit(repo_with_col):
     assert 'Error: Require commit message\n' in res.stdout
     res = runner.invoke(cli.commit, ['-m', 'test commit'])
     assert res.exit_code == 0
-    assert 'Commit message:\ntest commit\nCommit Successful. Digest' in res.stdout
-    stock._repo.hangar_repository._env._close_environments()
+    assert 'Commit message:\ntest commit' in res.stdout
+    assert 'Commit Successful. Digest' in res.stdout
+    stock._stock_repo.hangar_repo._env._close_environments()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ def test_init_repo():
         stock = StockRoom()
 
 
-def test_commit(repo_with_aset):
+def test_commit(repo_with_col):
     runner = CliRunner()
     stock = StockRoom()
     stock.tag['key'] = 'value'

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,24 +4,24 @@ import numpy as np
 
 def test_save_data(stock):
     arr = np.arange(20).reshape(4, 5)
-    stock.data['aset', 1] = arr
+    stock.data['ndcol', 1] = arr
     stock.commit("added data")
-    assert np.allclose(stock.data['aset', 1], arr)
+    assert np.allclose(stock.data['ndcol', 1], arr)
     del stock
 
 
 def test_save_to_non_existing_column(stock):
     arr = np.arange(20).reshape(4, 5)
     with pytest.raises(KeyError):
-        stock.data['wrongaset', 1] = arr
+        stock.data['wrongcol', 1] = arr
 
 
 def test_save_to_different_typed_column(stock):
     arr = np.arange(20).reshape(4, 5).astype(np.float)
     with pytest.raises(ValueError):
-        stock.data['aset', 1] = arr
+        stock.data['ndcol', 1] = arr
 
 
 def test_fetch_non_existing_sample_key(stock):
     with pytest.raises(KeyError):
-        stock.data['aset', 1]
+        stock.data['ndcol', 1]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,99 +2,93 @@ import pytest
 import numpy as np
 from copy import deepcopy
 
-
-class TestTFModelStore:
-
-    @staticmethod
-    def get_new_model():
-        import tensorflow as tf
-        tf_model = tf.keras.models.Sequential([
-            tf.keras.layers.Dense(3, activation='relu'),
-            tf.keras.layers.Dense(1, activation='relu')
-        ])
-        tf_model.build((5, 2))
-        return tf_model
-
-    @pytest.mark.filterwarnings('ignore:the imp module is deprecated:DeprecationWarning')
-    def test_saving_tf(self, stock):
-        tf_model = self.get_new_model()
-        old_weights = tf_model.get_weights()
-        stock.model.save_weights('tf_model', tf_model)
-        stock.commit("adding tf model")
-
-        tf_model = self.get_new_model()
-        tmp_weights = deepcopy(tf_model.get_weights())
-        stock.model.load_weights('tf_model', tf_model)
-        new_weights = deepcopy(tf_model.get_weights())
-        for k in range(len(old_weights)):
-            assert np.allclose(old_weights[k], new_weights[k])
-            # bias is initiated as zero in tensorflow hence
-            # the tmp and new both will be zero
-            assert not tmp_weights[k].sum() == 0.0 \
-                or np.allclose(tmp_weights[k], new_weights[k])
+import torch
+import tensorflow as tf
 
 
-class TestTorchModelStore:
+def get_torch_model():
 
-    @staticmethod
-    def get_new_model():
-        import torch
-        torch_model = torch.nn.Sequential(
-            torch.nn.Linear(2, 3),
-            torch.nn.ReLU(),
-            torch.nn.Linear(3, 1))
-        return torch_model
+    torch_model = torch.nn.Sequential(
+        torch.nn.Linear(2, 3),
+        torch.nn.ReLU(),
+        torch.nn.Linear(3, 1))
+    return torch_model, torch_model.state_dict, torch_model.load_state_dict
 
-    def test_saving_torch(self, stock):
-        torch_model = self.get_new_model()
-        old_state = torch_model.state_dict()
-        stock.model.save_weights('torch_model', torch_model)
-        stock.commit('adding torch model')
 
-        torch_model = self.get_new_model()
-        tmp_state = deepcopy(torch_model.state_dict())
-        stock.model.load_weights('torch_model', torch_model)
-        new_state = deepcopy(torch_model.state_dict())
-        for k in old_state.keys():
-            assert np.allclose(old_state[k], new_state[k])
-            assert not np.allclose(tmp_state[k], new_state[k])
+def get_tf_model():
+    tf_model = tf.keras.models.Sequential([
+        tf.keras.layers.Dense(3, activation='relu'),
+        tf.keras.layers.Dense(1, activation='relu')
+    ])
+    tf_model.build((5, 2))
+    return tf_model, tf_model.get_weights, tf_model.set_weights
 
-    def test_saving_two_models(self, stock):
-        torch_model1 = self.get_new_model()
-        torch_model2 = self.get_new_model()
-        state1 = torch_model1.state_dict()
-        state2 = torch_model2.state_dict()
-        stock.model[1] = state1
-        stock.model[2] = state2
-        stock.commit('adding two models')
-        ret_state1 = stock.model[1]
-        ret_state2 = stock.model[2]
-        torch_model1.load_state_dict(ret_state1)
-        torch_model2.load_state_dict(ret_state2)
-        for k in state1.keys():
-            assert np.allclose(ret_state1[k], state1[k])
-            assert np.allclose(ret_state2[k], state2[k])
 
-    def test_load_with_different_library_version(self, stock, monkeypatch):
-        import torch
-        torch_model = self.get_new_model()
-        stock.model.save_weights('thm', torch_model)
-        stock.commit("adding th model")
-        with monkeypatch.context() as m:
-            m.setattr(torch, '__version__', '0.9')
-            with pytest.warns(UserWarning) as warning_rec:
-                stock.model.load_weights('thm', torch_model)
-            assert len(warning_rec) == 1
-            assert "PyTorch version used" in warning_rec[0].message.args[0]
+# TODO: Ingore warning has no effect
+@pytest.mark.parametrize('get_model', [get_tf_model, get_torch_model])
+@pytest.mark.filterwarnings('ignore:the imp module is deprecated:DeprecationWarning')
+def test_saving_model(stock, get_model):
+    model, weight_getter, weight_setter = get_model()
+    old_weights = weight_getter()
+    stock.model.save_weights('model', model)
+    stock.commit('adding model')
 
-    def test_unknown_model_type(self, stock):
-        with pytest.raises(TypeError):
-            stock.model.save_weights('invalid', {})
+    model, weight_getter, weight_setter = get_model()
+    tmp_weights = deepcopy(weight_getter())
+    stock.model.load_weights('model', model)
+    new_weights = deepcopy(weight_getter())
+    iterator = old_weights.keys() if isinstance(old_weights, dict) else range(len(old_weights))
+    for k in iterator:
+        assert np.allclose(old_weights[k], new_weights[k])
+        # bias is initiated as zero in tensorflow hence
+        # the tmp and new both will be zero
+        assert not tmp_weights[k].sum() == 0.0 \
+            or np.allclose(tmp_weights[k], new_weights[k])
 
-    def test_load_nonexisting_key(self, stock):
-        thm = self.get_new_model()
-        stock.model.save_weights('thm', thm)
-        stock.commit("adding th model")
-        with pytest.raises(KeyError) as error:
-            stock.model.load_weights('wrongname', thm)
-        assert 'Model with key wrongname not found' == error.value.args[0]
+
+@pytest.mark.parametrize('get_model', [get_torch_model, get_tf_model])
+def test_saving_two_models(stock, get_model):
+    model1, weight_getter1, weight_setter1 = get_model()
+    model2, weight_getter2, weight_setter2 = get_model()
+    weights1 = weight_getter1()
+    weights2 = weight_getter2()
+    stock.model[1] = weights1
+    stock.model[2] = weights2
+    stock.commit('adding two models')
+    ret_weights1 = stock.model[1]
+    ret_weights2 = stock.model[2]
+    weight_setter1(ret_weights1)
+    weight_setter2(ret_weights2)
+    iterator = ret_weights1.keys() if isinstance(ret_weights1, dict) else range(len(ret_weights1))
+    for k in iterator:
+        assert np.allclose(ret_weights1[k], weights1[k])
+        assert np.allclose(ret_weights2[k], weights2[k])
+
+
+@pytest.mark.parametrize('get_model', [get_torch_model, get_tf_model])
+def test_load_with_different_library_version(stock, monkeypatch, get_model):
+    model, weight_getter, weight_setter = get_model()
+    stock.model.save_weights('model', model)
+    stock.commit("adding model")
+    with monkeypatch.context() as m:
+        m.setattr(torch, '__version__', '0.111')
+        m.setattr(tf, '__version__', '0.111')
+        with pytest.warns(UserWarning) as warning_rec:
+            stock.model.load_weights('model', model)
+        assert len(warning_rec) == 1
+        assert "version used while storing the model" in warning_rec[0].message.args[0]
+
+
+def test_unknown_model_type(stock):
+    with pytest.raises(TypeError):
+        stock.model.save_weights('invalid', {})
+
+
+@pytest.mark.parametrize('get_model', [get_torch_model, get_tf_model])
+def test_load_nonexisting_key(stock, get_model):
+    model, weight_getter, weight_setter = get_model()
+    stock.model.save_weights('model', model)
+    stock.commit("adding model")
+    with pytest.raises(KeyError) as error:
+        stock.model.load_weights('wrongname', model)
+    assert 'Model with key wrongname not found' == error.value.args[0]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -59,6 +59,22 @@ class TestTorchModelStore:
             assert np.allclose(old_state[k], new_state[k])
             assert not np.allclose(tmp_state[k], new_state[k])
 
+    def test_saving_two_models(self, stock):
+        torch_model1 = self.get_new_model()
+        torch_model2 = self.get_new_model()
+        state1 = torch_model1.state_dict()
+        state2 = torch_model2.state_dict()
+        stock.model[1] = state1
+        stock.model[2] = state2
+        stock.commit('adding two models')
+        ret_state1 = stock.model[1]
+        ret_state2 = stock.model[2]
+        torch_model1.load_state_dict(ret_state1)
+        torch_model2.load_state_dict(ret_state2)
+        for k in state1.keys():
+            assert np.allclose(ret_state1[k], state1[k])
+            assert np.allclose(ret_state2[k], state2[k])
+
     def test_load_with_different_library_version(self, stock, monkeypatch):
         import torch
         torch_model = self.get_new_model()

--- a/tests/test_multiple_instances.py
+++ b/tests/test_multiple_instances.py
@@ -13,12 +13,12 @@ class TestSameProcess:
         oldarr = arr * randint(1, 100)
         newarr = arr * randint(1, 100)
 
-        stock.data['aset', 1] = oldarr
-        stock2.data['aset', 1] = newarr
+        stock.data['ndcol', 1] = oldarr
+        stock2.data['ndcol', 1] = newarr
         stock.commit('added data')
 
-        assert np.allclose(stock2.data['aset', 1], newarr)
-        assert not np.allclose(stock2.data['aset', 1], oldarr)
+        assert np.allclose(stock2.data['ndcol', 1], newarr)
+        assert not np.allclose(stock2.data['ndcol', 1], oldarr)
         stock2._repo.hangar_repository._env._close_environments()
 
     def test_one_in_write_contextmanager(self, stock):
@@ -41,20 +41,20 @@ class TestSameProcess:
                     pass
 
             with pytest.raises(PermissionError):
-                stock2.data['aset', 1] = oldarr
+                stock2.data['ndcol', 1] = oldarr
 
-            stock.data['aset', 1] = oldarr
+            stock.data['ndcol', 1] = oldarr
             stock.commit('adding data inside cm')
 
             with pytest.raises(KeyError):
                 # TODO: document this scenario
-                data = stock.data['aset', 1]
+                data = stock.data['ndcol', 1]
 
             stock3 = StockRoom()
             assert stock3._repo._optimized_Rcheckout is None
             assert stock3._repo._optimized_Wcheckout is None
 
-        assert np.allclose(oldarr, stock.data['aset', 1])
+        assert np.allclose(oldarr, stock.data['ndcol', 1])
         stock2._repo.hangar_repository._env._close_environments()
         stock3._repo.hangar_repository._env._close_environments()
 
@@ -63,7 +63,7 @@ class TestSameProcess:
         arr = np.arange(20).reshape(4, 5)
 
         with stock.optimize():
-            stock2.data['aset', 1] = arr
+            stock2.data['ndcol', 1] = arr
             stock2.commit('adding data')
 
             with stock2.optimize(write=True):
@@ -72,8 +72,8 @@ class TestSameProcess:
                 assert stock._repo._optimized_Rcheckout is not None
                 assert stock._repo._optimized_Wcheckout is None
 
-                stock2.data['aset', 2] = arr
+                stock2.data['ndcol', 2] = arr
                 stock2.commit('adding data')
-        assert np.allclose(stock.data['aset', 1], arr)
-        assert np.allclose(stock.data['aset', 2], arr)
+        assert np.allclose(stock.data['ndcol', 1], arr)
+        assert np.allclose(stock.data['ndcol', 2], arr)
         stock2._repo.hangar_repository._env._close_environments()

--- a/tests/test_multiple_instances.py
+++ b/tests/test_multiple_instances.py
@@ -19,25 +19,20 @@ class TestSameProcess:
 
         assert np.allclose(stock2.data['ndcol', 1], newarr)
         assert not np.allclose(stock2.data['ndcol', 1], oldarr)
-        stock2._repo.hangar_repository._env._close_environments()
+        stock2._stock_repo.hangar_repo._env._close_environments()
 
     def test_one_in_write_contextmanager(self, stock):
         stock2 = StockRoom()
         arr = np.arange(20).reshape(4, 5)
         oldarr = arr * randint(1, 100)
 
-        with stock.optimize(write=True):
-            assert stock._repo._optimized_Rcheckout is not None
-            assert stock._repo._optimized_Wcheckout is not None
-            assert stock2._repo._optimized_Rcheckout is None
-            assert stock2._repo._optimized_Wcheckout is None
+        with stock.optimize():
+            assert stock._stock_repo.is_write_optimized
+            assert not stock2._stock_repo.is_write_optimized
 
-            with stock2.optimize():
-                pass
-
-            # write optimization
+            # another write optimization
             with pytest.raises(PermissionError):
-                with stock2.optimize(write=True):
+                with stock2.optimize():
                     pass
 
             with pytest.raises(PermissionError):
@@ -45,35 +40,11 @@ class TestSameProcess:
 
             stock.data['ndcol', 1] = oldarr
             stock.commit('adding data inside cm')
-
-            with pytest.raises(KeyError):
-                # TODO: document this scenario
-                data = stock.data['ndcol', 1]
+            assert np.allclose(stock.data['ndcol', 1], oldarr)
 
             stock3 = StockRoom()
-            assert stock3._repo._optimized_Rcheckout is None
-            assert stock3._repo._optimized_Wcheckout is None
+            assert not stock3._stock_repo.is_write_optimized
 
         assert np.allclose(oldarr, stock.data['ndcol', 1])
-        stock2._repo.hangar_repository._env._close_environments()
-        stock3._repo.hangar_repository._env._close_environments()
-
-    def test_one_in_read_contextmanager(self, stock):
-        stock2 = StockRoom()
-        arr = np.arange(20).reshape(4, 5)
-
-        with stock.optimize():
-            stock2.data['ndcol', 1] = arr
-            stock2.commit('adding data')
-
-            with stock2.optimize(write=True):
-                assert stock2._repo._optimized_Wcheckout is not None
-                assert stock2._repo._optimized_Rcheckout is not None
-                assert stock._repo._optimized_Rcheckout is not None
-                assert stock._repo._optimized_Wcheckout is None
-
-                stock2.data['ndcol', 2] = arr
-                stock2.commit('adding data')
-        assert np.allclose(stock.data['ndcol', 1], arr)
-        assert np.allclose(stock.data['ndcol', 2], arr)
-        stock2._repo.hangar_repository._env._close_environments()
+        stock2._stock_repo.hangar_repo._env._close_environments()
+        stock3._stock_repo.hangar_repo._env._close_environments()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -61,13 +61,13 @@ class TestCommit:
     def test_commit_hash(self, stock):
         stock.tag['key1'] = 'value'
         stock.commit('generic data')
-        with open(stock._repo.stockroot/'head.stock') as f:
+        with open(stock._stock_repo.stockroot/'head.stock') as f:
             digest1 = f.read()
         stock.tag['key2'] = 'value2'
         stock.commit('generic data 2')
-        with open(stock._repo.stockroot/'head.stock') as f:
+        with open(stock._stock_repo.stockroot/'head.stock') as f:
             digest2 = f.read()
-        log = stock._repo._hangar_repo.log(return_contents=True)
+        log = stock._stock_repo.hangar_repo.log(return_contents=True)
         log['order'].pop()  # removing the digest from conftest.py
         assert log['order'] == [digest2, digest1]
 

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -14,3 +14,13 @@ def test_basic(stock):
 def test_save_string(stock):
     with pytest.raises(TypeError):
         stock.tag['wrongdata'] = bytes('hi')
+
+
+@pytest.mark.skip(reason="Commit level metadata needs to be implemented in hangar")
+def test_no_commit_history(stock):
+    stock.tag['lr'] = 0
+    stock.commit('adding lr')
+    stock.tag['key'] = 'val'
+    stock.commit('adding someval')
+    with pytest.raises(KeyError):
+        stock.tag['lr']

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -6,6 +6,7 @@ def test_basic(stock):
     stock.tag['epochs'] = 500
     stock.tag['optimizer'] = 'adam'
     stock.commit('Saved lr')
+
     assert stock.tag['lr'] == 0.01
     assert stock.tag['optimizer'] == 'adam'
     assert stock.tag['epochs'] == 500


### PR DESCRIPTION
## Description
Currently, both read and write optimizations are implemented under the context managers. But since hangar allows multiple read checkout and the reliability of `atexit` hooks are good enough for read checkout, we can open the optimized read checkout globally and hence increase read speed

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
